### PR TITLE
Embed tarball of QEMU's source inside container

### DIFF
--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -73,6 +73,8 @@ RUN \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /var/lib/apt/lists/*
 
 RUN \
+  wget -c -nv -P / \
+  "https://download.qemu.org/qemu-${QEMU_VER}.tar.xz" && \
   wget -c -nv \
   "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-$(uname -m).AppImage" \
   -O /usr/local/bin/linuxdeployqt.appimage && \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -25,6 +25,8 @@ RUN \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /var/lib/apt/lists/*
 
 RUN \
+  wget -c -nv -P / \
+  "https://download.qemu.org/qemu-${QEMU_VER}.tar.xz" && \
   wget -c -nv \
   "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-$(uname -m).AppImage" \
   -O /usr/local/bin/linuxdeployqt.appimage && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -208,8 +208,12 @@ makeAppImage() {
 
 # Download QEMU's source code
 if [ ! -x ./configure ]; then
-	wget "https://download.qemu.org/qemu-${VERSION}.tar.xz" -O - \
-		| tar -xJv --strip-components=1 || exit
+	if [ -f "/qemu-${VERSION}.tar.xz" ]; then
+		tar -xJv --strip-components=1 -f "/qemu-${VERSION}.tar.xz" || exit
+	else
+		wget "https://download.qemu.org/qemu-${VERSION}.tar.xz" -O - \
+			| tar -xJv --strip-components=1 || exit
+	fi
 elif [ -f ./VERSION ]; then
 	VERSION=$(cat ./VERSION)
 fi


### PR DESCRIPTION
Download and save the tarball of QEMU's source code on container creation so we can use the container offline with no required downloads unless a different version of QEMU is specified via `QEMU_VER` variable.